### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This toolbox was written by Dr. Mitchell Harley at the University of New South W
 
 2.  Download the MATLAB files of this GitHub site to the CoastSnap/Code directory
 
-3.  Make sure you have the following Matlab toolkits installed: mapping toolbox, Statistics and ML toolbox, Image processing toolbox
+3.  Make sure you have the following Matlab toolkits installed: mapping toolbox, Statistics and ML toolbox, Image processing toolbox and Curve Fitting Toolbox
 
 4.  Update the following two files to match your local setup: CSPsetPaths.m and CSPloadPaths.m
 


### PR DESCRIPTION
Added in one more matlab toolbox (i.e. Curve Fitting Toolbox) required to run the coastsnap code. This extra toolbox is only required to run one line of code within CSPGmakeBeachWidthAnimation (the part that fits a nice curve through beach width data).